### PR TITLE
Fix breaking spatie/laravel-permission

### DIFF
--- a/src/LivewireResourceTimeGridServiceProvider.php
+++ b/src/LivewireResourceTimeGridServiceProvider.php
@@ -19,12 +19,14 @@ class LivewireResourceTimeGridServiceProvider extends ServiceProvider
                 __DIR__.'/../resources/views' => $this->app->resourcePath('views/vendor/livewire-resource-time-grid'),
             ], 'livewire-resource-time-grid');
         }
+        
+        $this->bladeDirectives();
     }
 
     /**
      * Register the application services.
      */
-    public function register()
+    public function bladeDirectives()
     {
         Blade::directive('livewireResourceTimeGridScripts', function () {
             return <<<'HTML'


### PR DESCRIPTION
Using `Blade::directive` directly inside `register()` may break the `blade.compiler` container that maybe used in other packages.
`spatie/laravel-permission` seems to be the one. It maybe effective to fix it in this package or I need to contact spatie.

```
$this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
            $bladeCompiler->directive('role', function ($arguments) {
                list($role, $guard) = explode(',', $arguments.',');

                return "<?php if(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
            });
            $bladeCompiler->directive('elserole', function ($arguments) {
                list($role, $guard) = explode(',', $arguments.',');

                return "<?php elseif(auth({$guard})->check() && auth({$guard})->user()->hasRole({$role})): ?>";
            });
            $bladeCompiler->directive('endrole', function () {
                return '<?php endif; ?>';
            });
...
});
```