### PR TITLE
Move Blade Directive to boot()

### DIFF
--- a/src/LivewireResourceTimeGridServiceProvider.php
+++ b/src/LivewireResourceTimeGridServiceProvider.php
@@ -19,13 +19,7 @@ class LivewireResourceTimeGridServiceProvider extends ServiceProvider
                 __DIR__.'/../resources/views' => $this->app->resourcePath('views/vendor/livewire-resource-time-grid'),
             ], 'livewire-resource-time-grid');
         }
-    }
-
-    /**
-     * Register the application services.
-     */
-    public function register()
-    {
+        
         Blade::directive('livewireResourceTimeGridScripts', function () {
             return <<<'HTML'
             <script>


### PR DESCRIPTION
The Blade Directive should be called in the boot() method, otherwise it will cause problems with Jetstream for example (eg. it's not 100% sure you get the same View instance because not all providers are registered yet)