### PR TITLE
Adds back support for Livewire v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "illuminate/support": "^7.0|^8.0",
-        "livewire/livewire": "^2.0"
+        "livewire/livewire": "^1.0|^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0|^6.0",


### PR DESCRIPTION
This package seems to still be working fine with both versions of Livewire. 

Would make upgrading to Laravel 8 a lot easier as we wouldn't be forced to also upgrade to Livewire v2.

🤠