### PR TITLE
ConflictingEvents fix

### DIFF
--- a/src/Exceptions/InvalidPeriod.php
+++ b/src/Exceptions/InvalidPeriod.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Asantibanez\LivewireResourceTimeGrid\Exceptions;
+
+use DateTimeInterface;
+use InvalidArgumentException;
+
+class InvalidPeriod extends InvalidArgumentException
+{
+    public static function endBeforeStart(DateTimeInterface $start, DateTimeInterface $end): InvalidPeriod
+    {
+        return new static("The event end time `{$end->format('H:i')}` is before the start time `{$start->format('H:i')}`.");
+    }
+}

--- a/src/LivewireResourceTimeGrid.php
+++ b/src/LivewireResourceTimeGrid.php
@@ -224,15 +224,8 @@ class LivewireResourceTimeGrid extends Component
 
     private function getEventConflictingNeighborEvents($event, $events) : Collection
     {
-        if($this->isMidnight($event['ends_at'])) {
-            $event['ends_at'] = (clone $event['ends_at'])->subMinutes(1);
-        }
         return $events
             ->filter(function ($item) use ($event) {
-                if($this->isMidnight($item['ends_at'])) {
-                    $item['ends_at'] = (clone $item['ends_at'])->subMinutes(1);
-                }
-
                 return (
                         $event['starts_at']->betweenIncluded($item['starts_at'], $item['ends_at'])
                         && $event['ends_at']->betweenIncluded($item['starts_at'], $item['ends_at'])

--- a/src/LivewireResourceTimeGrid.php
+++ b/src/LivewireResourceTimeGrid.php
@@ -160,11 +160,6 @@ class LivewireResourceTimeGrid extends Component
             ;
     }
 
-    private function isMidnight(Carbon $time): bool
-    {
-        return $time->format('H:i') === '00:00';
-    }
-
     private function getCheckedEvents(): Collection
     {
         return $this->events()
@@ -175,16 +170,13 @@ class LivewireResourceTimeGrid extends Component
                                             ->setHour($event['ends_at']->format('G'))
                                             ->setMinute($event['ends_at']->format('i'));
                 }
-                if($this->isMidnight($event['ends_at'])) {
+                if($event['ends_at']->format('H:i') === '00:00') {
                     $event['ends_at']->addDays(1);
                 }
                 return $event;
             })
             ->each(function($event) {
-                if(
-                    !$this->isMidnight($event['ends_at'])
-                    && $event['ends_at']->isBefore($event['starts_at'])
-                ) {
+                if($event['ends_at']->isBefore($event['starts_at'])) {
                     throw InvalidPeriod::endBeforeStart($event['starts_at'], $event['ends_at']);
                 }
             });


### PR DESCRIPTION
Bug #11 

There was no check if event starting time is before than event ending time, which led to grid rendering bug.

What changed:

- [x] checks if starts_at actually comes before ends_at. If not it throws InvalidArgumentException

- [x] while getting conflicting events, it treats ends_at midnight as 0:00 of next day, which doesn't overlap anymore with other events.